### PR TITLE
Bug #24901 Fix. 

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -885,7 +885,7 @@ class BaseChatOpenAI(BaseChatModel):
                 else:
                     # Cast str(value) in case the message value is not a string
                     # This occurs with function messages
-                    num_tokens += len(encoding.encode(value))
+                    num_tokens += len(encoding.encode(str(value)))
                 if key == "name":
                     num_tokens += tokens_per_name
         # every reply is primed with <im_start>assistant


### PR DESCRIPTION
**Description:** This pull request fixes #24901.

get_num_tokens_from_messages method in langchain_openai/chat_models/base.py generates "TypeError: expected string or buffer" error

It modifies the libs/partners/openai/langchain_openai/chat_models/base.py file.

**Issue:** #24901